### PR TITLE
[FIX][9.0] add instead of override NET rule to avoid update issue

### DIFF
--- a/l10n_cn_hr_payroll/data/salary_rule_basic.xml
+++ b/l10n_cn_hr_payroll/data/salary_rule_basic.xml
@@ -307,7 +307,7 @@
             <field name="amount_percentage">100.0</field>
         </record>
 
-        <record id="hr_payroll.hr_rule_net" model="hr.salary.rule">
+        <record id="hr_rule_basic_net" model="hr.salary.rule">
             <field name="name">Basic Net</field>
             <field name="sequence" eval="700"/>
             <field name="code">BASICNET</field>

--- a/l10n_cn_hr_payroll/data/salary_rule_nj1.xml
+++ b/l10n_cn_hr_payroll/data/salary_rule_nj1.xml
@@ -191,7 +191,7 @@
             <field name="company_id" ref="base.main_company"/>
             <field eval="[(6, 0, [
                     ref('hr_rule_basic_pit_base'),
-                    ref('hr_payroll.hr_rule_net'),
+                    ref('hr_rule_basic_net'),
                     ref('hr_rule_sl'),
                     ref('hr_rule_lsl'),
                     ref('hr_rule_upl'),

--- a/l10n_cn_hr_payroll/data/salary_rule_sh1.xml
+++ b/l10n_cn_hr_payroll/data/salary_rule_sh1.xml
@@ -178,7 +178,7 @@
             <field name="company_id" ref="base.main_company"/>
             <field eval="[(6, 0, [
                     ref('hr_rule_basic_pit_base'),
-                    ref('hr_payroll.hr_rule_net'),
+                    ref('hr_rule_basic_net'),
                     ref('hr_rule_sl'),
                     ref('hr_rule_lsl'),
                     ref('hr_rule_upl'),

--- a/l10n_cn_hr_payroll/data/salary_rule_sh2.xml
+++ b/l10n_cn_hr_payroll/data/salary_rule_sh2.xml
@@ -178,7 +178,7 @@
             <field name="company_id" ref="base.main_company"/>
             <field eval="[(6, 0, [
                     ref('hr_payroll.hr_rule_basic'),
-                    ref('hr_payroll.hr_rule_net'),
+                    ref('hr_rule_basic_net'),
                     ref('hr_rule_sl'),
                     ref('hr_rule_lsl'),
                     ref('hr_rule_upl'),

--- a/l10n_cn_hr_payroll/data/salary_rule_sh3.xml
+++ b/l10n_cn_hr_payroll/data/salary_rule_sh3.xml
@@ -178,7 +178,7 @@
             <field name="company_id" ref="base.main_company"/>
             <field eval="[(6, 0, [
                     ref('hr_rule_basic_pit_base'),
-                    ref('hr_payroll.hr_rule_net'),
+                    ref('hr_rule_basic_net'),
                     ref('hr_rule_sl'),
                     ref('hr_rule_lsl'),
                     ref('hr_rule_upl'),

--- a/l10n_cn_hr_payroll/data/salary_rule_sh4.xml
+++ b/l10n_cn_hr_payroll/data/salary_rule_sh4.xml
@@ -9,7 +9,7 @@
             <field name="company_id" ref="base.main_company"/>
             <field eval="[(6, 0, [
                     ref('hr_payroll.hr_rule_basic'),
-                    ref('hr_payroll.hr_rule_net'),
+                    ref('hr_rule_basic_net'),
                     ref('hr_rule_sl'),
                     ref('hr_rule_lsl'),
                     ref('hr_rule_upl'),

--- a/l10n_cn_hr_payroll/data/salary_rule_sz1.xml
+++ b/l10n_cn_hr_payroll/data/salary_rule_sz1.xml
@@ -178,7 +178,7 @@
             <field name="company_id" ref="base.main_company"/>
             <field eval="[(6, 0, [
                     ref('hr_rule_basic_pit_base'),
-                    ref('hr_payroll.hr_rule_net'),
+                    ref('hr_rule_basic_net'),
                     ref('hr_rule_sl'),
                     ref('hr_rule_lsl'),
                     ref('hr_rule_upl'),

--- a/l10n_cn_hr_payroll/data/salary_rule_sz2.xml
+++ b/l10n_cn_hr_payroll/data/salary_rule_sz2.xml
@@ -187,7 +187,7 @@
                     ref('hr_rule_bonuse'),
                     ref('hr_rule_adj'),
                     ref('hr_rule_topay'),
-                    ref('hr_payroll.hr_rule_net'),
+                    ref('hr_rule_basic_net'),
                     ref('hr_rule_pension1_sz2'),
                     ref('hr_rule_medical_sz2'),
                     ref('hr_rule_bearing_sz2'),

--- a/l10n_cn_hr_payroll/data/salary_rule_sz3.xml
+++ b/l10n_cn_hr_payroll/data/salary_rule_sz3.xml
@@ -184,7 +184,7 @@
                     ref('hr_rule_bonuse'),
                     ref('hr_rule_adj'),
                     ref('hr_rule_topay'),
-                    ref('hr_payroll.hr_rule_net'),
+                    ref('hr_rule_basic_net'),
                     ref('hr_rule_pension1_sz3'),
                     ref('hr_rule_medical_sz3'),
                     ref('hr_rule_bearing_sz3'),

--- a/l10n_cn_hr_payroll/data/salary_rule_sz4.xml
+++ b/l10n_cn_hr_payroll/data/salary_rule_sz4.xml
@@ -184,7 +184,7 @@
                     ref('hr_rule_bonuse'),
                     ref('hr_rule_adj'),
                     ref('hr_rule_topay'),
-                    ref('hr_payroll.hr_rule_net'),
+                    ref('hr_rule_basic_net'),
                     ref('hr_rule_pension1_sz4'),
                     ref('hr_rule_medical_sz4'),
                     ref('hr_rule_bearing_sz4'),


### PR DESCRIPTION
This PR fixes the issue when updating from an old version, that the inherited `NET` rule won't be updated. The reason why we update the `NET` rule is because this [336](https://github.com/OCA/hr/pull/336). We'd better have only one rule of 'NET' category.

The solution is adding a new rule `BASICNET` instead of inheriting and overriding the `NET` rule from `hr_payroll` module.

cc @elicoidal 